### PR TITLE
 remove compiler specifier

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,8 +82,6 @@ SOFTWARE.
   </distributionManagement>
   <properties>
     <eolang.version>0.28.10</eolang.version>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
Closes: #14

We don't need to specify compiler version since we have the lowest one in our parent project